### PR TITLE
Enhance testing setup with Playwright and ESLint configurations

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .history/
+playwright/.auth

--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -1,0 +1,9 @@
+import invenioE2E from "@inveniosoftware/invenio-e2e";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+	{
+		files: ["**/*.ts"],
+		extends: [invenioE2E],
+	},
+]);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,8 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "prettier": "prettier --check \"{src,tests,scripts}/**/*.{ts,js,json,md}\"",
+    "prettier:fix": "prettier --write \"{src,tests,scripts}/**/*.{ts,js,json,md}\"",
     "collect-translations": "invenio-e2e-collect-translations",
-    "i18n-setup": "node -e \"require('invenio-e2e').tools.i18n_setup(process.argv.slice(2))\""
+    "collect-translations:validate": "invenio-e2e-collect-translations --validate",
+    "generate-pot": "invenio-e2e-generate-pot",
+    "i18n:validate": "npm run generate-pot && npm run collect-translations:validate"
   },
   "keywords": [],
   "author": "",
@@ -13,12 +19,22 @@
   "devDependencies": {
     "@playwright/test": "^1.54.1",
     "@types/node": "^24.0.13",
-    "ts-deepmerge": "^7.0.3"
+    "ts-deepmerge": "^7.0.3",
+    "playwright-qase-reporter": "^2.1.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "i18next-conv": "^15.1.1",
     "module-alias": "^2.2.3",
     "@inveniosoftware/invenio-e2e": "workspace:*"
+  },
+  "optionalDependencies": {
+    "eslint": "^9.36.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jsdoc": "^60.5.0",
+    "typescript-eslint": "^8.44.1",
+    "prettier": "^3.6.2"
   },
   "_moduleAliases": {
     "@collected-translations": "./translations"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,7 +21,6 @@
     "@types/node": "^24.0.13",
     "ts-deepmerge": "^7.0.3",
     "playwright-qase-reporter": "^2.1.5",
-    "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import 'module-alias/register';
+import { appConfig } from '@inveniosoftware/invenio-e2e';
 import { defineConfig, devices } from '@playwright/test';
 
 /**
@@ -24,11 +25,31 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   timeout: 10_000,
-  reporter: 'html',
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  // Multiple reporters (console + HTML + Qase)
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    // ...(appConfig.qase
+    //   ? [
+    //       [
+    //         "playwright-qase-reporter",
+    //         {
+    //           apiToken: appConfig.qase.apiToken,
+    //           projectCode: appConfig.qase.projectCode,
+    //           runName: appConfig.qase.runName || `E2E Run - ${new Date().toISOString()}`,
+    //           environment: appConfig.qase.environment,
+    //           rootSuiteTitle: appConfig.qase.rootSuiteTitle,
+    //           runComplete: appConfig.qase.runComplete,
+    //         },
+    //       ] as const,
+    //     ]
+    //   : []),
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://127.0.0.1:5000',
+    baseURL: appConfig.baseURL,
 
     /* Allow self-signed certificates */
     ignoreHTTPSErrors: true,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, devices } from '@playwright/test';
 import 'module-alias/register';
+import { defineConfig, devices } from '@playwright/test';
 
 /**
  * Read environment variables from file.
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://127.0.0.1:5000/',
+    baseURL: 'https://127.0.0.1:5000',
 
     /* Allow self-signed certificates */
     ignoreHTTPSErrors: true,
@@ -53,19 +53,31 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: /api\/.*/,
       use: { ...devices['Desktop Chrome'] },
     },
-    /*
-        {
-          name: 'firefox',
-          use: { ...devices['Desktop Firefox'] },
-        },
-    
-        {
-          name: 'webkit',
-          use: { ...devices['Desktop Safari'] },
-        },
-    */
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* API Testing */
+    { name: 'API Testing Setup', 
+      testMatch: /api\/.*\.setup\.ts$/ 
+    },
+    {
+      name: 'API',
+      testMatch: /api\/.*\.spec.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      dependencies: ['API Testing Setup'],
+    },
     /* Test against mobile viewports. */
     // {
     //   name: 'Mobile Chrome',

--- a/e2e/tests/api/auth.setup.ts
+++ b/e2e/tests/api/auth.setup.ts
@@ -1,0 +1,7 @@
+import { setupApiTesting } from "@inveniosoftware/invenio-e2e";
+
+import path from 'path';
+
+const authFilePath = path.join(__dirname, '../../playwright/.auth/user.json');
+
+setupApiTesting(authFilePath);

--- a/e2e/tests/api/auth.setup.ts
+++ b/e2e/tests/api/auth.setup.ts
@@ -1,7 +1,7 @@
-import { setupApiTesting } from "@inveniosoftware/invenio-e2e";
+import { appConfig, setupApiTesting } from "@inveniosoftware/invenio-e2e";
 
 import path from 'path';
 
-const authFilePath = path.join(__dirname, '../../playwright/.auth/user.json');
+const authFileAbsolutePath = path.resolve(__dirname, '../../', appConfig.authUserFilePath);
 
-setupApiTesting(authFilePath);
+setupApiTesting(authFileAbsolutePath);

--- a/e2e/tests/api/invenio-api.spec.ts
+++ b/e2e/tests/api/invenio-api.spec.ts
@@ -1,0 +1,31 @@
+import { test, recordsApiTests } from '@inveniosoftware/invenio-e2e';
+
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const authUserFilePath = process.env.AUTH_USER_FILE || path.join(__dirname, '../../playwright/.auth/user.json');
+const authUserFile = JSON.parse(readFileSync(authUserFilePath, 'utf-8'));
+
+test.use({
+  storageState: authUserFilePath,
+  extraHTTPHeaders: {
+    'X-CSRFToken': authUserFile.cookies.find((cookie: { name: string, value?: string }) => cookie.name === 'csrftoken')?.value || '',
+    'Referer': process.env.BASE_URL || 'https://127.0.0.1:5000',
+  },
+});
+
+// Run all API tests by calling the function with the test instance
+
+recordsApiTests(test, "/api/records");
+
+/*
+ * To skip some tests inside the default test suite, you can use the `skipTests` method:
+ * 
+ *
+ * test.skipTests(['Should display the homepage logo'], () => {
+ *   // This will skip the test with the title 'Should display the homepage logo'
+ *   homepageTests(test);
+ *   loginTests(test);
+ * })
+ *  
+ */

--- a/e2e/tests/api/invenio-api.spec.ts
+++ b/e2e/tests/api/invenio-api.spec.ts
@@ -1,22 +1,24 @@
-import { test, recordsApiTests } from '@inveniosoftware/invenio-e2e';
+import { test, recordsApiTests, appConfig } from '@inveniosoftware/invenio-e2e';
 
+import type { BrowserContext } from "@playwright/test";
 import { readFileSync } from 'fs';
 import path from 'path';
 
-const authUserFilePath = process.env.AUTH_USER_FILE || path.join(__dirname, '../../playwright/.auth/user.json');
-const authUserFile = JSON.parse(readFileSync(authUserFilePath, 'utf-8'));
+const authUserFilePath = path.resolve(__dirname, '../../', appConfig.authUserFilePath);
+const authUserFile = JSON.parse(readFileSync(authUserFilePath, 'utf-8')) as Awaited<ReturnType<BrowserContext['storageState']>>;
 
 test.use({
   storageState: authUserFilePath,
   extraHTTPHeaders: {
-    'X-CSRFToken': authUserFile.cookies.find((cookie: { name: string, value?: string }) => cookie.name === 'csrftoken')?.value || '',
-    'Referer': process.env.BASE_URL || 'https://127.0.0.1:5000',
+    'X-CSRFToken': authUserFile.cookies.find(cookie => cookie.name === 'csrftoken')?.value || '',
+    'Referer': appConfig.baseURL || 'https://127.0.0.1:5000',
   },
 });
 
+
 // Run all API tests by calling the function with the test instance
 
-recordsApiTests(test, "/api/records");
+recordsApiTests(test);
 
 /*
  * To skip some tests inside the default test suite, you can use the `skipTests` method:

--- a/e2e/tests/invenio.spec.ts
+++ b/e2e/tests/invenio.spec.ts
@@ -1,5 +1,7 @@
-import { homepageTests, test, depositionTests, loginTests } from '@inveniosoftware/invenio-e2e';
+import { homepageTests, test, loginTests, depositionTests, i18nValidationTests, i18nPOTTests } from '@inveniosoftware/invenio-e2e';
 
 homepageTests(test);
 loginTests(test);
 depositionTests(test);
+i18nPOTTests(test);
+i18nValidationTests(test);

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../invenio-e2e/tsconfig.json",
+  "exclude": [
+    "node_modules/**", 
+    "playwright-report/**", 
+    "test-results/**"
+  ]
+}


### PR DESCRIPTION
- Updated .gitignore to include playwright/.auth
- Added linting and formatting scripts to package.json
- Configured Playwright for API testing in playwright.config.ts
- Expanded test cases in invenio.spec.ts to include i18n tests
- Introduced ESLint configuration for TypeScript files
- Set up API testing in auth.setup.ts
- Implemented API tests in invenio-api.spec.ts
- Created tsconfig.json for TypeScript project settings